### PR TITLE
解决 zip 文件未被关闭的问题及部分编译警告

### DIFF
--- a/miniunz.c
+++ b/miniunz.c
@@ -214,6 +214,8 @@ static int do_list(uf)
         }
     }
 
+    unzClose(uf);
+
     return 0;
 }
 
@@ -233,7 +235,6 @@ static int do_extract_currentfile(uf,popt_extract_without_path,popt_overwrite,pa
     uInt size_buf;
 
     unz_file_info file_info;
-    uLong ratio=0;
     err = unzGetCurrentFileInfo(uf,&file_info,filename_inzip,sizeof(filename_inzip),NULL,0,NULL,0);
 
     if (err!=UNZ_OK)
@@ -367,14 +368,14 @@ static int do_extract_currentfile(uf,popt_extract_without_path,popt_overwrite,pa
 
         if (err==UNZ_OK)
         {
-            err = unzCloseCurrentFile (uf);
+            err = unzClose(uf);
             if (err!=UNZ_OK)
             {
-                printf("error %d with zipfile in unzCloseCurrentFile\n",err);
+                printf("error %d with zipfile in unzClose\n",err);
             }
         }
         else
-            unzCloseCurrentFile(uf); /* don't lose the error */
+            unzClose(uf); /* don't lose the error */
     }
 
     free(buf);
@@ -391,7 +392,6 @@ static int do_extract(uf,opt_extract_without_path,opt_overwrite,password)
     uLong i;
     unz_global_info gi;
     int err;
-    FILE* fout=NULL;
 
     err = unzGetGlobalInfo (uf,&gi);
     if (err!=UNZ_OK)
@@ -425,7 +425,6 @@ static int do_extract_onefile(uf,filename,opt_extract_without_path,opt_overwrite
     int opt_overwrite;
     const char* password;
 {
-    int err = UNZ_OK;
     if (unzLocateFile(uf,filename,CASESENSITIVITY)!=UNZ_OK)
     {
         printf("file %s not found in the zipfile\n",filename);
@@ -545,7 +544,7 @@ static int miniunz_main(argc,argv)
             return do_extract_onefile(uf,filename_to_extract,
                                       opt_do_extract_withoutpath,opt_overwrite,password);
     }
-    unzCloseCurrentFile(uf);
+    unzClose(uf);
 
     return 0;
 }

--- a/minizip.c
+++ b/minizip.c
@@ -139,7 +139,7 @@ static int getFileCrc(const char* filenameinzip,void*buf,unsigned long size_buf,
         fclose(fin);
 
     *result_crc=calculate_crc;
-    printf("file %s crc %x\n",filenameinzip,calculate_crc);
+    printf("file %s crc %lx\n",filenameinzip,calculate_crc);
     return err;
 }
 

--- a/unzip.c
+++ b/unzip.c
@@ -608,10 +608,12 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
 
     /* we check the magic */
     if (err==UNZ_OK)
+    {
         if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
             err=UNZ_ERRNO;
         else if (uMagic!=0x02014b50)
             err=UNZ_BADZIPFILE;
+    }
 
     if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version) != UNZ_OK)
         err=UNZ_ERRNO;
@@ -688,10 +690,13 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
             uSizeRead = extraFieldBufferSize;
 
         if (lSeek!=0)
+        {
             if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
                 lSeek=0;
             else
                 err=UNZ_ERRNO;
+        }
+
         if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
             if (ZREAD(s->z_filefunc, s->filestream,extraField,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
@@ -713,10 +718,13 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
             uSizeRead = commentBufferSize;
 
         if (lSeek!=0)
+        {
             if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
                 lSeek=0;
             else
                 err=UNZ_ERRNO;
+        }
+
         if ((file_info.size_file_comment>0) && (commentBufferSize>0))
             if (ZREAD(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
@@ -977,10 +985,12 @@ local int unzlocal_CheckCurrentFileCoherencyHeader (s,piSizeVar,
 
 
     if (err==UNZ_OK)
+    {
         if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
             err=UNZ_ERRNO;
         else if (uMagic!=0x04034b50)
             err=UNZ_BADZIPFILE;
+    }
 
     if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
         err=UNZ_ERRNO;
@@ -1534,7 +1544,6 @@ extern int ZEXPORT unzGetGlobalComment (file, szComment, uSizeBuf)
     char *szComment;
     uLong uSizeBuf;
 {
-    int err=UNZ_OK;
     unz_s* s;
     uLong uReadThis ;
     if (file==NULL)

--- a/zip.c
+++ b/zip.c
@@ -189,12 +189,12 @@ local void init_linkedlist(ll)
     ll->first_block = ll->last_block = NULL;
 }
 
-local void free_linkedlist(ll)
-    linkedlist_data* ll;
-{
-    free_datablock(ll->first_block);
-    ll->first_block = ll->last_block = NULL;
-}
+// local void free_linkedlist(ll)
+//     linkedlist_data* ll;
+// {
+//     free_datablock(ll->first_block);
+//     ll->first_block = ll->last_block = NULL;
+// }
 
 
 local int add_data_in_datablock(ll,buf,len)


### PR DESCRIPTION
- 经核查源代码，unzCloseCurrentFile 只释放了内存, 并未调用
关闭文件的接口, unzClose 可以正常关闭文件，故全部改用 unzClose.
ref:
https://github.com/mysterywolf/minizip/blob/7ec06eeb2dcf7bad661bcfe4ddfde4bb929c4aa8/unzip.c#L511-L525

- 解决几处比较明显的编译警告

Signed-off-by: a1012112796 <1012112796@qq.com>

fix #1 