### PR TITLE
解决解压多文件zip报错问题

### DIFF
--- a/miniunz.c
+++ b/miniunz.c
@@ -368,14 +368,14 @@ static int do_extract_currentfile(uf,popt_extract_without_path,popt_overwrite,pa
 
         if (err==UNZ_OK)
         {
-            err = unzClose(uf);
+            err = unzCloseCurrentFile(uf);
             if (err!=UNZ_OK)
             {
-                printf("error %d with zipfile in unzClose\n",err);
+                printf("error %d with zipfile in unzCloseCurrentFile\n",err);
             }
         }
         else
-            unzClose(uf); /* don't lose the error */
+            unzCloseCurrentFile(uf); /* don't lose the error */
     }
 
     free(buf);
@@ -415,6 +415,8 @@ static int do_extract(uf,opt_extract_without_path,opt_overwrite,password)
         }
     }
 
+    unzClose(uf);
+
     return 0;
 }
 
@@ -433,10 +435,14 @@ static int do_extract_onefile(uf,filename,opt_extract_without_path,opt_overwrite
 
     if (do_extract_currentfile(uf,&opt_extract_without_path,
                                       &opt_overwrite,
-                                      password) == UNZ_OK)
+                                      password) == UNZ_OK) {
+        unzClose(uf);
         return 0;
-    else
+    }
+    else {
+        unzClose(uf);
         return 1;
+    }
 }
 
 


### PR DESCRIPTION
之前的代码在测试`miniunz`解压具有多个文件的`zip`时报错，报错命令为`miniunz -x target.zip`，报错内容为`error -1 with zipfile in unzGoToNextFile`，完整运行日志如下所示，测试平台为`bsp/qemu-virt64-aarch64`。
```
msh />echo test a.txt
msh />echo test b.txt
msh />minizip -o -9 target.zip a.txt b.txt
MiniZip 1.01b, demo of zLib + Zip package written by Gilles Vollant
more info at http://www.winimage.com/zLibDll/minizip.html

creating target.zip
msh />rm a.txt b.txt
msh />miniunz -x target.zip
MiniUnz 1.01b, demo of zLib + Unz package written by Gilles Vollant
more info at http://www.winimage.com/zLibDll/minizip.html

target.zip opened
 extracting: a.txt
error -1 with zipfile in unzGoToNextFile
```
经过调试后发现在解压多个文件时存在利用`unzClose`提前关闭文件的情形，个人更正并且测试通过，测试如下。
```
msh />ls
Directory /:
target.zip          206                      
msh />miniunz -l target.zip
MiniUnz 1.01b, demo of zLib + Unz package written by Gilles Vollant
more info at http://www.winimage.com/zLibDll/minizip.html

target.zip opened
 Length  Method   Size  Ratio   Date    Time   CRC-32     Name
 ------  ------   ----  -----   ----    ----   ------     ----
      4  Defl:X       6 150%  01-00-80  00:00  d87f7e0c   a.txt
      4  Defl:X       6 150%  01-00-80  00:00  d87f7e0c   b.txt
msh />
msh />miniunz -x target.zip 
MiniUnz 1.01b, demo of zLib + Unz package written by Gilles Vollant
more info at http://www.winimage.com/zLibDll/minizip.html

target.zip opened
 extracting: a.txt
 extracting: b.txt
```